### PR TITLE
fix: replace hyphens in DE codes with underscores since RapidPro does…

### DIFF
--- a/src/main/resources/dataValueSet.ds
+++ b/src/main/resources/dataValueSet.ds
@@ -1,8 +1,10 @@
-local normaliseFn(dataElementCodes) = ds.map(dataElementCodes, function(v, i) ds.replace(ds.lower(v), ' ', '_'));
+local normaliseDeCodeFn(dataElementCode) = ds.replace(ds.replace(ds.lower(dataElementCode), ' ', '_'), '-', '_');
+
+local normaliseDeCodesFn(dataElementCodes) = ds.map(dataElementCodes, function(v, i) normaliseDeCodeFn(v));
 
 local dataValueFn(result) = [
     {
-      dataElement: ds.filter(cml.header('dataElementCodes'), function(v, i) ds.replace(ds.lower(v), ' ', '_') == result.key)[0],
+      dataElement: ds.filter(cml.header('dataElementCodes'), function(v, i) normaliseDeCodeFn(v) == result.key)[0],
       value: result.value.value
     }
 ];
@@ -12,5 +14,5 @@ local dataValueFn(result) = [
     orgUnit: payload.contact.dhis2_organisation_unit_id,
     dataSet: payload.flow.data_set_id,
     period: '2021W19',
-    dataValues: std.flatMap(dataValueFn, ds.filter(ds.entriesOf(payload.results), function(v, i) ds.contains(normaliseFn(cml.header('dataElementCodes')), v.key)))
+    dataValues: std.flatMap(dataValueFn, ds.filter(ds.entriesOf(payload.results), function(v, i) ds.contains(normaliseDeCodesFn(cml.header('dataElementCodes')), v.key)))
 }

--- a/src/test/java/org/hisp/dhis/integration/rapidpro/ExpressionTestCase.java
+++ b/src/test/java/org/hisp/dhis/integration/rapidpro/ExpressionTestCase.java
@@ -59,7 +59,7 @@ public class ExpressionTestCase
         dsExpression.setBodyMediaType( "application/x-java-object" );
         dsExpression.setOutputMediaType( "application/x-java-object" );
 
-        List<String> dataElementCodes = List.of( "GEN_EXT_FUND", "MAL_POP_TOTAL", "MAL_LLIN_DISTR_PW", "GEN_DOMESTIC FUND", "MAL_LLIN_DISTR_NB", "MAL_PEOPLE_PROT_BY_IRS", "MAL_POP_AT_RISK", "GEN_PREG_EXPECT", "GEN_FUND_NEED" );
+        List<String> dataElementCodes = List.of( "GEN_EXT_FUND", "MAL-POP-TOTAL", "MAL_LLIN_DISTR_PW", "GEN_DOMESTIC FUND", "MAL_LLIN_DISTR_NB", "MAL_PEOPLE_PROT_BY_IRS", "MAL_POP_AT_RISK", "GEN_PREG_EXPECT", "GEN_FUND_NEED" );
 
         Exchange exchange = new DefaultExchange( new DefaultCamelContext() );
         exchange.getMessage().setHeader( "dataElementCodes", dataElementCodes );
@@ -77,7 +77,7 @@ public class ExpressionTestCase
         List<Map<String, Object>> dataValues = (List<Map<String, Object>>) dataValueSet.get( "dataValues" );
         assertEquals( "GEN_EXT_FUND", dataValues.get( 0 ).get( "dataElement" ) );
         assertEquals( "2", dataValues.get( 0 ).get( "value" ) );
-        assertEquals( "MAL_POP_TOTAL", dataValues.get( 1 ).get( "dataElement" ) );
+        assertEquals( "MAL-POP-TOTAL", dataValues.get( 1 ).get( "dataElement" ) );
         assertEquals( "10", dataValues.get( 1 ).get( "value" ) );
         assertEquals( "MAL_LLIN_DISTR_PW", dataValues.get( 2 ).get( "dataElement" ) );
         assertEquals( "3", dataValues.get( 2 ).get( "value" ) );


### PR DESCRIPTION
…n't permit hyphens in names