### PR TITLE
Support editing of reports and manual retries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,10 @@
             <artifactId>camel-spring-boot-starter</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-spring-jdbc-starter</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.hisp.dhis.integration.camel</groupId>
             <artifactId>camel-dhis2</artifactId>
             <version>1.0.1-SNAPSHOT</version>

--- a/src/main/java/org/hisp/dhis/integration/rapidpro/expression/RootExceptionMessageExpression.java
+++ b/src/main/java/org/hisp/dhis/integration/rapidpro/expression/RootExceptionMessageExpression.java
@@ -1,0 +1,16 @@
+package org.hisp.dhis.integration.rapidpro.expression;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Expression;
+import org.springframework.core.NestedExceptionUtils;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RootExceptionMessageExpression implements Expression
+{
+    @Override
+    public <T> T evaluate( Exchange exchange, Class<T> type )
+    {
+        return (T) NestedExceptionUtils.getRootCause( (Throwable) exchange.getProperty(Exchange.EXCEPTION_CAUGHT) ).getMessage();
+    }
+}

--- a/src/main/resources/dataValueSet.ds
+++ b/src/main/resources/dataValueSet.ds
@@ -6,7 +6,7 @@ local dataValueFn(result) = [
     {
       dataElement: ds.filter(cml.header('dataElementCodes'), function(v, i) normaliseDeCodeFn(v) == result.key)[0],
       value: result.value.value,
-      comment: 'RapidPro Contact Details: %s' % std.escapeStringJson(std.manifestJsonEx(payload.contact, ' '))
+      comment: 'RapidPro contact details: %s' % std.escapeStringJson(std.manifestJsonEx(payload.contact, ' '))
     }
 ];
 

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,5 +1,6 @@
 CREATE TABLE IF NOT EXISTS DLQ (
-    id      INTEGER                           NOT NULL PRIMARY KEY AUTO_INCREMENT,
-    payload VARCHAR                           NOT NULL,
-    status  ENUM('PROCESSED', 'RETRY', 'ERROR') NOT NULL
+    id              INTEGER                             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    payload         VARCHAR                             NOT NULL,
+    error_message   VARCHAR                             NOT NULL,
+    status          ENUM('PROCESSED', 'RETRY', 'ERROR') NOT NULL
 );

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS DLQ (
+    id      INTEGER                           NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    payload VARCHAR                           NOT NULL,
+    status  ENUM('PROCESSED', 'RETRY', 'ERROR') NOT NULL
+);

--- a/src/test/java/org/hisp/dhis/integration/rapidpro/AbstractFunctionalTestCase.java
+++ b/src/test/java/org/hisp/dhis/integration/rapidpro/AbstractFunctionalTestCase.java
@@ -40,6 +40,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
 import io.restassured.specification.RequestSpecification;
@@ -48,15 +50,19 @@ import io.restassured.specification.RequestSpecification;
 @CamelSpringBootTest
 @UseAdviceWith
 @ActiveProfiles( "test" )
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class AbstractFunctionalTestCase
 {
+    protected static RequestSpecification RAPIDPRO_API_REQUEST_SPEC;
+
     @Autowired
     protected CamelContext camelContext;
 
     @Autowired
     protected ProducerTemplate producerTemplate;
 
-    protected static RequestSpecification RAPIDPRO_API_REQUEST_SPEC;
+    @Autowired
+    protected JdbcTemplate jdbcTemplate;
 
     @BeforeAll
     public static void beforeAll()
@@ -69,6 +75,8 @@ public class AbstractFunctionalTestCase
     {
         System.clearProperty( "sync.dhis2.users" );
         System.clearProperty( "org.unit.id.scheme" );
+
+        jdbcTemplate.execute( "DELETE FROM DLQ" );
 
         for ( Map<String, Object> contact : fetchRapidProContacts() )
         {

--- a/src/test/java/org/hisp/dhis/integration/rapidpro/DataValueSetDataSonnetTestCase.java
+++ b/src/test/java/org/hisp/dhis/integration/rapidpro/DataValueSetDataSonnetTestCase.java
@@ -98,7 +98,7 @@ public class DataValueSetDataSonnetTestCase
         assertEquals( "5", dataValues.get( 3 ).get( "value" ) );
 
         assertEquals(
-            "RapidPro Contact Details: \"{\\n \\\"name\\\": \\\"John Doe\\\",\\n \\\"urn\\\": \\\"tel:+12065551212\\\",\\n \\\"uuid\\\": \\\"fb3787ab-2eda-48a0-a2bc-e2ddadec1286\\\",\\n \\\"dhis2_organisation_unit_id\\\": \\\"%s\\\"\\n}\"",
+            "RapidPro contact details: \"{\\n \\\"name\\\": \\\"John Doe\\\",\\n \\\"urn\\\": \\\"tel:+12065551212\\\",\\n \\\"uuid\\\": \\\"fb3787ab-2eda-48a0-a2bc-e2ddadec1286\\\",\\n \\\"dhis2_organisation_unit_id\\\": \\\"%s\\\"\\n}\"",
             dataValues.get( 0 ).get( "comment" ) );
     }
 }

--- a/src/test/java/org/hisp/dhis/integration/rapidpro/Environment.java
+++ b/src/test/java/org/hisp/dhis/integration/rapidpro/Environment.java
@@ -76,6 +76,8 @@ public final class Environment
 
     public static final Dhis2Client DHIS2_CLIENT;
 
+    public static GenericContainer<?> DHIS2_CONTAINER;
+
     private static final Logger LOGGER = LoggerFactory.getLogger( Environment.class );
 
     private static final Network RAPIDPRO_NETWORK = Network.builder().id( "rapidProNetwork" ).build();
@@ -89,8 +91,6 @@ public final class Environment
     private static GenericContainer<?> RAPIDPRO_CONTAINER;
 
     private static GenericContainer<?> MAILROOM_CONTAINER;
-
-    private static GenericContainer<?> DHIS2_CONTAINER;
 
     public static final RequestSpecification RAPIDPRO_REQUEST_SPEC;
 

--- a/src/test/java/org/hisp/dhis/integration/rapidpro/route/DataValueSetRouteBuilderFunctionalTestCase.java
+++ b/src/test/java/org/hisp/dhis/integration/rapidpro/route/DataValueSetRouteBuilderFunctionalTestCase.java
@@ -27,36 +27,42 @@
  */
 package org.hisp.dhis.integration.rapidpro.route;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.util.Date;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.camel.CamelExecutionException;
 import org.apache.camel.ExchangePattern;
+import org.apache.camel.builder.AdviceWith;
+import org.apache.camel.component.mock.MockEndpoint;
 import org.hisp.dhis.api.model.v2_37_7.DataValueSet;
 import org.hisp.dhis.api.model.v2_37_7.DataValue__1;
 import org.hisp.dhis.integration.rapidpro.AbstractFunctionalTestCase;
 import org.hisp.dhis.integration.rapidpro.Environment;
 import org.hisp.dhis.integration.sdk.support.period.PeriodBuilder;
 import org.junit.jupiter.api.Test;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.util.StreamUtils;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DataValueSetRouteBuilderFunctionalTestCase extends AbstractFunctionalTestCase
 {
     @Test
-    @DirtiesContext
     public void testDataValueSetIsCreated()
-        throws IOException
+        throws IOException, InterruptedException
     {
         camelContext.start();
 
         String webhookMessage = StreamUtils.copyToString(
             Thread.currentThread().getContextClassLoader().getResourceAsStream( "webhook.json" ),
             Charset.defaultCharset() );
-        producerTemplate.sendBody( "jms:queue:reports",
+        producerTemplate.sendBody( "jms:queue:dhis2",
             ExchangePattern.InOut, String.format( webhookMessage, Environment.ORG_UNIT_ID ) );
 
         DataValueSet dataValueSet = Environment.DHIS2_CLIENT.get(
@@ -72,7 +78,56 @@ public class DataValueSetRouteBuilderFunctionalTestCase extends AbstractFunction
     }
 
     @Test
-    @DirtiesContext
+    public void testRecordInDlqIsCreatedGivenErrorWhileCreatingDataValueSet()
+        throws IOException
+    {
+        System.setProperty( "org.unit.id.scheme", "bar" );
+        camelContext.start();
+
+        String webhookMessage = StreamUtils.copyToString(
+            Thread.currentThread().getContextClassLoader().getResourceAsStream( "webhook.json" ),
+            Charset.defaultCharset() );
+
+        assertThrows( CamelExecutionException.class, () -> producerTemplate.sendBody( "jms:queue:dhis2",
+            ExchangePattern.InOut, String.format( webhookMessage, Environment.ORG_UNIT_ID ) ) );
+
+        List<Map<String, Object>> dlq = jdbcTemplate.queryForList( "SELECT * FROM DLQ" );
+        assertEquals( 1, dlq.size() );
+        assertEquals( "ERROR", dlq.get( 0 ).get( "STATUS" ) );
+        Map<String, Object> payload = new ObjectMapper().readValue( (String) dlq.get( 0 ).get( "PAYLOAD" ), Map.class );
+        assertEquals( "John Doe", ((Map<String, Object>) payload.get( "contact" )).get( "name" ) );
+    }
+
+    @Test
+    public void testRetryRecordInDlqIsReProcessed()
+        throws Exception
+    {
+        AdviceWith.adviceWith( camelContext, "dhis2Route", r -> r.weaveAddLast().to( "mock:spy" ) );
+        MockEndpoint spyEndpoint = camelContext.getEndpoint( "mock:spy", MockEndpoint.class );
+        spyEndpoint.setExpectedCount( 1 );
+
+        System.setProperty( "org.unit.id.scheme", "bar" );
+        camelContext.start();
+
+        String webhookMessage = StreamUtils.copyToString(
+            Thread.currentThread().getContextClassLoader().getResourceAsStream( "webhook.json" ),
+            Charset.defaultCharset() );
+
+        assertThrows( CamelExecutionException.class, () -> producerTemplate.sendBody( "jms:queue:dhis2",
+            ExchangePattern.InOut, String.format( webhookMessage, Environment.ORG_UNIT_ID ) ) );
+        assertEquals( 0, spyEndpoint.getReceivedCounter() );
+
+        System.setProperty( "org.unit.id.scheme", "ID" );
+        jdbcTemplate.execute( "UPDATE DLQ SET STATUS = 'RETRY' WHERE STATUS = 'ERROR'" );
+        spyEndpoint.await( 10, TimeUnit.SECONDS );
+
+        assertEquals( 1, spyEndpoint.getReceivedCounter() );
+        List<Map<String, Object>> dlq = jdbcTemplate.queryForList( "SELECT * FROM DLQ" );
+        assertEquals( 1, dlq.size() );
+        assertEquals( "PROCESSED", dlq.get( 0 ).get( "STATUS" ) );
+    }
+
+    @Test
     public void testDataValueSetIsCreatedGivenOrgUnitIdSchemeIsCode()
         throws IOException
     {
@@ -82,7 +137,7 @@ public class DataValueSetRouteBuilderFunctionalTestCase extends AbstractFunction
         String webhookMessage = StreamUtils.copyToString(
             Thread.currentThread().getContextClassLoader().getResourceAsStream( "webhook.json" ),
             Charset.defaultCharset() );
-        producerTemplate.sendBody( "jms:queue:reports",
+        producerTemplate.sendBody( "jms:queue:dhis2",
             ExchangePattern.InOut, String.format( webhookMessage, "ACME" ) );
 
         DataValueSet dataValueSet = Environment.DHIS2_CLIENT.get(

--- a/src/test/java/org/hisp/dhis/integration/rapidpro/route/DataValueSetRouteBuilderFunctionalTestCase.java
+++ b/src/test/java/org/hisp/dhis/integration/rapidpro/route/DataValueSetRouteBuilderFunctionalTestCase.java
@@ -94,6 +94,9 @@ public class DataValueSetRouteBuilderFunctionalTestCase extends AbstractFunction
         List<Map<String, Object>> dlq = jdbcTemplate.queryForList( "SELECT * FROM DLQ" );
         assertEquals( 1, dlq.size() );
         assertEquals( "ERROR", dlq.get( 0 ).get( "STATUS" ) );
+        assertEquals( String.format(
+                "Response{protocol=http/1.1, code=500, message=, url=http://localhost:%s/api/dataValueSets?dataElementIdScheme=CODE&orgUnitIdScheme=bar}", Environment.DHIS2_CONTAINER.getFirstMappedPort() ),
+            dlq.get( 0 ).get( "ERROR_MESSAGE" ) );
         Map<String, Object> payload = new ObjectMapper().readValue( (String) dlq.get( 0 ).get( "PAYLOAD" ), Map.class );
         assertEquals( "John Doe", ((Map<String, Object>) payload.get( "contact" )).get( "name" ) );
     }

--- a/src/test/java/org/hisp/dhis/integration/rapidpro/route/SyncRouteBuilderFunctionalTestCase.java
+++ b/src/test/java/org/hisp/dhis/integration/rapidpro/route/SyncRouteBuilderFunctionalTestCase.java
@@ -52,7 +52,6 @@ import com.github.javafaker.Faker;
 public class SyncRouteBuilderFunctionalTestCase extends AbstractFunctionalTestCase
 {
     @Test
-    @DirtiesContext
     public void testContactSynchronisationFailsGivenThatSyncDhis2UsersPropertyIsFalse()
     {
         System.setProperty( "sync.dhis2.users", "false" );
@@ -63,7 +62,6 @@ public class SyncRouteBuilderFunctionalTestCase extends AbstractFunctionalTestCa
     }
 
     @Test
-    @DirtiesContext
     public void testFirstSynchronisationCreatesContacts()
     {
         camelContext.start();
@@ -76,7 +74,6 @@ public class SyncRouteBuilderFunctionalTestCase extends AbstractFunctionalTestCa
     }
 
     @Test
-    @DirtiesContext
     public void testContactSynchronisationGivenOrgUnitIdSchemeIsCode()
     {
         System.setProperty( "org.unit.id.scheme", "CODE" );
@@ -91,7 +88,6 @@ public class SyncRouteBuilderFunctionalTestCase extends AbstractFunctionalTestCa
     }
 
     @Test
-    @DirtiesContext
     public void testNextSynchronisationUpdatesRapidProContactGivenUpdatedDhis2User()
     {
         camelContext.start();


### PR DESCRIPTION
Create a DLQ relational table on start-up and record data value sets which couldn't be saved in this table so that they can be edited and retried.