### PR TITLE
Allow routes to be overridden at config time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ build/
 *.log
 *.gz
 *.jks
+routes/

--- a/README.md
+++ b/README.md
@@ -405,7 +405,11 @@ Integration flows in DHIS-to-RapidPro, known as [routes](https://camel.apache.or
 | Create RapidPro Group  | Creates contact group on RapidPro                                                      |
 | Sync RapidPro Contacts | Synchronises RapidPro contacts with DHIS2 users                                        |
 
-You should place the file or files containing the custom routes in a directory named `camel` within DHIS-to-RapidPro's current directory. The custom route will override the inbuilt route if the routes match by name. DHIS-to-RapidPro can reload the routes while its running therefore you have the option to extend the application at runtime. What follows is an example of a custom YAML route that overrides the inbuilt `Deliver Report` route:
+You should place the file or files containing the custom routes in a directory named `routes` within DHIS-to-RapidPro's current directory. The custom route will override the inbuilt route if the routes match by name. DHIS-to-RapidPro can reload the routes while its running therefore you have the option to extend the application at runtime.
+
+>**IMPORTANT:** Hot reloading is only recommended for non-production environments. 
+
+What follows is an example of a custom YAML route that overrides the inbuilt `Deliver Report` route:
 
 ```yaml
 - route:
@@ -434,7 +438,7 @@ You should place the file or files containing the custom routes in a directory n
 
 The above custom route overrides the original route such that aggregate reports are delivered to a non-DHIS2 system. It extracts a number of values from the report payload with the `setProperty` key and adds them to destination URL as HTTP query parameters. Consult the [Set Property](https://camel.apache.org/components/3.18.x/eips/setProperty-eip.html) and [JSONPath](https://camel.apache.org/components/3.18.x/languages/jsonpath-language.html) Apache Camel documentation for further information about setting properties and extracting values from within a route.
 
-Besides adding query parameters, the route also configures the HTTP client for basic authentication using the reserved query parameters `authenticationPreemptive`, `authMethod`, `authUsername`, and `authPassword`. Consult the [HTTP component Apache Camel documentation](https://camel.apache.org/components/3.18.x/http-component.html) for further information about configuring the HTTP client.
+Besides adding query parameters, the route also configures the HTTP client for basic authentication using the reserved query parameters `authenticationPreemptive`, `authMethod`, `authUsername`, and `authPassword`. Consult the [HTTP component](https://camel.apache.org/components/3.18.x/http-component.html) Apache Camel documentation for further information about configuring the HTTP client.
 
 ## Troubleshooting Guide
 

--- a/src/main/java/org/hisp/dhis/integration/rapidpro/Application.java
+++ b/src/main/java/org/hisp/dhis/integration/rapidpro/Application.java
@@ -31,6 +31,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import org.apache.activemq.artemis.core.config.storage.DatabaseStorageConfiguration;
 import org.apache.camel.CamelContext;
+import org.apache.commons.io.FileUtils;
 import org.hisp.dhis.integration.rapidpro.security.KeyStoreGenerator;
 import org.hisp.dhis.integration.sdk.Dhis2ClientBuilder;
 import org.hisp.dhis.integration.sdk.api.Dhis2Client;
@@ -46,6 +47,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.PropertySource;
 
 import javax.annotation.PostConstruct;
+import java.io.File;
 import java.io.IOException;
 import java.sql.SQLException;
 
@@ -94,6 +96,7 @@ public class Application extends SpringBootServletInitializer
         throws
         IOException
     {
+        FileUtils.forceMkdir( new File( "routes" ) );
         keyStoreGenerator.generate();
         camelContext.getRegistry().bind( "native", nativeDataSonnetLibrary );
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -45,5 +45,6 @@ org.unit.id.scheme=ID
 
 camel.springboot.main-run-controller=true
 camel.springboot.routes-reload-enabled=true
-camel.springboot.routes-reload-directory=camel
+camel.springboot.routes-reload-directory=routes
 camel.springboot.routes-reload-remove-all-routes=false
+camel.springboot.routes-include-pattern=file:routes/*

--- a/src/test/java/org/hisp/dhis/integration/rapidpro/AbstractFunctionalTestCase.java
+++ b/src/test/java/org/hisp/dhis/integration/rapidpro/AbstractFunctionalTestCase.java
@@ -31,6 +31,7 @@ import static io.restassured.RestAssured.given;
 import static org.hisp.dhis.integration.rapidpro.Environment.DHIS2_CLIENT;
 
 import java.io.File;
+import java.io.IOException;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -46,6 +47,7 @@ import org.apache.commons.io.FileUtils;
 import org.hisp.dhis.api.model.v2_36_11.DataValueSet;
 import org.hisp.dhis.api.model.v2_36_11.DataValue__1;
 import org.hisp.dhis.integration.sdk.support.period.PeriodBuilder;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -91,8 +93,7 @@ public class AbstractFunctionalTestCase
         throws
         Exception
     {
-        FileUtils.deleteDirectory( new File( "target/test-classes/camel" ) );
-        new File( "target/test-classes/camel" ).mkdir();
+        FileUtils.deleteDirectory( new File( "routes" ) );
 
         System.clearProperty( "sync.rapidpro.contacts" );
         System.clearProperty( "org.unit.id.scheme" );
@@ -137,7 +138,14 @@ public class AbstractFunctionalTestCase
         throws
         Exception
     {
+    }
 
+    @AfterEach
+    public void afterEach()
+        throws
+        IOException
+    {
+        FileUtils.deleteDirectory( new File( "routes" ) );
     }
 
     protected List<Map<String, Object>> fetchRapidProContacts()

--- a/src/test/java/org/hisp/dhis/integration/rapidpro/ExtensibilityTestCase.java
+++ b/src/test/java/org/hisp/dhis/integration/rapidpro/ExtensibilityTestCase.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.integration.rapidpro;
+
+import org.apache.camel.Route;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Test;
+import org.springframework.util.StreamUtils;
+
+import java.io.File;
+import java.nio.charset.Charset;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ExtensibilityTestCase extends AbstractFunctionalTestCase
+{
+    @Test
+    public void testOverrideRoute()
+        throws
+        Exception
+    {
+        System.setProperty( "sync.rapidpro.contacts", "true" );
+        System.setProperty( "report.destination.endpoint",
+            "https://localhost:" + serverPort + "/dhis2rapidpro/legacy" );
+
+        camelContext.getRegistry().bind( "selfSignedHttpClientConfigurer", new SelfSignedHttpClientConfigurer() );
+        camelContext.addRoutes( new RouteBuilder()
+        {
+            @Override
+            public void configure()
+            {
+                from( "servlet:legacy?httpMethodRestrict=POST" ).to( "mock:destination" ).removeHeaders( "*" );
+            }
+        } );
+        MockEndpoint spyEndpoint = camelContext.getEndpoint( "mock:destination", MockEndpoint.class );
+        spyEndpoint.setExpectedCount( 1 );
+
+        FileUtils.forceMkdir( new File( "routes" ) );
+
+        camelContext.start();
+
+        FileUtils.copyFile( new File( this.getClass().getResource( "/deliverReport.yaml" ).getFile() ),
+            new File( "routes/deliverReport.yaml" ) );
+
+        while ( true )
+        {
+            Thread.sleep( 5000 );
+            Route deliverReportRoute = camelContext.getRoute( "Deliver Report" );
+            if ( deliverReportRoute.getSourceLocationShort() != null && deliverReportRoute.getSourceLocationShort()
+                .equals( "deliverReport.yaml:4" ) )
+            {
+                break;
+            }
+        }
+
+        String contactUuid = syncContactsAndFetchFirstContactUuid();
+        String webhookMessage = StreamUtils.copyToString(
+            Thread.currentThread().getContextClassLoader().getResourceAsStream( "webhook.json" ),
+            Charset.defaultCharset() );
+        producerTemplate.requestBody(
+            dhis2RapidProHttpEndpointUri
+                + "/webhook?aParam=aValue&dataSetCode=MAL_YEARLY&httpClientConfigurer=#selfSignedHttpClientConfigurer&httpMethod=POST",
+            String.format( webhookMessage, contactUuid ), String.class );
+
+        spyEndpoint.await( 5000, TimeUnit.MILLISECONDS );
+
+        assertEquals( 1, spyEndpoint.getReceivedCounter() );
+        Map<String, Object> headers = spyEndpoint.getReceivedExchanges().get( 0 ).getMessage().getHeaders();
+        assertEquals( "aValue", headers.get( "aParam" ) );
+        assertEquals( "Basic YWxpY2U6c2VjcmV0", headers.get( "Authorization" ) );
+    }
+}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,4 +1,2 @@
 dhis2.api.username = admin
 dhis2.api.password = district
-
-camel.springboot.routes-reload-directory=target/test-classes/camel


### PR DESCRIPTION
Allow routes to be overridden at config-time instead of supporting only hot reloading

BREAKING CHANGE: custom routes are expected in "routes" directory instead of "camel" directory