### PR TITLE
Read contact from message body once

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
                 <configuration>
                     <trimStackTrace>false</trimStackTrace>
                     <failIfNoTests>true</failIfNoTests>
+                    <skipAfterFailureCount>1</skipAfterFailureCount>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/org/hisp/dhis/integration/rapidpro/ContactOrgUnitIdAggrStrategy.java
+++ b/src/main/java/org/hisp/dhis/integration/rapidpro/ContactOrgUnitIdAggrStrategy.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.integration.rapidpro;
+
+import com.jayway.jsonpath.JsonPath;
+import org.apache.camel.AggregationStrategy;
+import org.apache.camel.Exchange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+public class ContactOrgUnitIdAggrStrategy implements AggregationStrategy
+{
+    protected static final Logger LOGGER = LoggerFactory.getLogger( ContactOrgUnitIdAggrStrategy.class );
+
+    @Override
+    public Exchange aggregate( Exchange oldExchange, Exchange newExchange )
+    {
+        String contact = newExchange.getMessage().getBody( String.class );
+        String contactUuid = (String) ((Map<String, Object>) oldExchange.getMessage().getBody( Map.class )
+            .get( "contact" )).get( "uuid" );
+        LOGGER.debug( String.format( "Fetched contact %s => %s ", contactUuid, contact ) );
+        oldExchange.getMessage()
+            .setHeader( "orgUnitId", JsonPath.read( contact, "$.results[0].fields.dhis2_organisation_unit_id" ) );
+        return oldExchange;
+    }
+}

--- a/src/test/java/org/hisp/dhis/integration/rapidpro/ContactOrgUnitIdAggrStrategyTestCase.java
+++ b/src/test/java/org/hisp/dhis/integration/rapidpro/ContactOrgUnitIdAggrStrategyTestCase.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.integration.rapidpro;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.support.DefaultExchange;
+import org.apache.camel.support.DefaultMessage;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ContactOrgUnitIdAggrStrategyTestCase
+{
+    @Test
+    public void testAggregateGivenInputStreamInNewExchangeBody()
+        throws
+        IOException
+    {
+        CamelContext camelContext = new DefaultCamelContext();
+
+        Exchange oldExchange = new DefaultExchange( camelContext );
+        Message oldMessage = new DefaultMessage( camelContext );
+        oldMessage.setBody( Map.of( "contact", Map.of( "uuid", UUID.randomUUID().toString() ) ) );
+        oldExchange.setMessage( oldMessage );
+
+        PipedInputStream pipedInputStream = new PipedInputStream();
+        PipedOutputStream pipedOutputStream = new PipedOutputStream( pipedInputStream );
+        new ObjectMapper().writeValue( pipedOutputStream,
+            Map.of( "results",
+                List.of( Map.of( "fields", Map.of( "dhis2_organisation_unit_id", "fdc6uOvgoji" ) ) ) ) );
+
+        Exchange newExchange = new DefaultExchange( camelContext );
+        Message newMessage = new DefaultMessage( camelContext );
+        newMessage.setBody( pipedInputStream );
+        newExchange.setMessage( newMessage );
+
+        ContactOrgUnitIdAggrStrategy contactOrgUnitIdAggrStrategy = new ContactOrgUnitIdAggrStrategy();
+        Exchange aggregateExchange = contactOrgUnitIdAggrStrategy.aggregate( oldExchange, newExchange );
+        assertEquals( "fdc6uOvgoji", aggregateExchange.getMessage().getHeader( "orgUnitId" ) );
+    }
+
+    @Test
+    public void testAggregate()
+        throws
+        IOException
+    {
+        CamelContext camelContext = new DefaultCamelContext();
+
+        Exchange oldExchange = new DefaultExchange( camelContext );
+        Message oldMessage = new DefaultMessage( camelContext );
+        oldMessage.setBody( Map.of( "contact", Map.of( "uuid", UUID.randomUUID().toString() ) ) );
+        oldExchange.setMessage( oldMessage );
+
+        Exchange newExchange = new DefaultExchange( camelContext );
+        Message newMessage = new DefaultMessage( camelContext );
+        newMessage.setBody( new ObjectMapper().writeValueAsString( Map.of( "results",
+                List.of( Map.of( "fields", Map.of( "dhis2_organisation_unit_id", "fdc6uOvgoji" ) ) ) ) ) );
+        newExchange.setMessage( newMessage );
+
+        ContactOrgUnitIdAggrStrategy contactOrgUnitIdAggrStrategy = new ContactOrgUnitIdAggrStrategy();
+        Exchange aggregateExchange = contactOrgUnitIdAggrStrategy.aggregate( oldExchange, newExchange );
+        assertEquals( "fdc6uOvgoji", aggregateExchange.getMessage().getHeader( "orgUnitId" ) );
+    }
+}

--- a/src/test/java/org/hisp/dhis/integration/rapidpro/route/TransmitReportRouteBuilderFunctionalTestCase.java
+++ b/src/test/java/org/hisp/dhis/integration/rapidpro/route/TransmitReportRouteBuilderFunctionalTestCase.java
@@ -89,13 +89,13 @@ public class TransmitReportRouteBuilderFunctionalTestCase extends AbstractFuncti
     }
 
     @Test
-    @Timeout( value = 5, unit = TimeUnit.MINUTES )
+    @Timeout( value = 6, unit = TimeUnit.MINUTES )
     public void testScheduledReportDelivery()
         throws
         Exception
     {
         System.setProperty( "sync.rapidpro.contacts", "true" );
-        System.setProperty( "report.delivery.schedule.expression", "0 0/3 * * * ?" );
+        System.setProperty( "report.delivery.schedule.expression", "0 0/4 * * * ?" );
         AdviceWith.adviceWith( camelContext, "Deliver Report", r -> r.weaveAddLast().to( "mock:spy" ) );
         MockEndpoint spyEndpoint = camelContext.getEndpoint( "mock:spy", MockEndpoint.class );
         spyEndpoint.setExpectedCount( 1 );

--- a/src/test/java/org/hisp/dhis/integration/rapidpro/route/TransmitReportRouteBuilderFunctionalTestCase.java
+++ b/src/test/java/org/hisp/dhis/integration/rapidpro/route/TransmitReportRouteBuilderFunctionalTestCase.java
@@ -89,18 +89,19 @@ public class TransmitReportRouteBuilderFunctionalTestCase extends AbstractFuncti
     }
 
     @Test
-    @Timeout( value = 6, unit = TimeUnit.MINUTES )
+    @Timeout( value = 5, unit = TimeUnit.MINUTES )
     public void testScheduledReportDelivery()
         throws
         Exception
     {
         System.setProperty( "sync.rapidpro.contacts", "true" );
-        System.setProperty( "report.delivery.schedule.expression", "0 0/4 * * * ?" );
+        System.setProperty( "report.delivery.schedule.expression", "0 0/1 * * * ?" );
         AdviceWith.adviceWith( camelContext, "Deliver Report", r -> r.weaveAddLast().to( "mock:spy" ) );
         MockEndpoint spyEndpoint = camelContext.getEndpoint( "mock:spy", MockEndpoint.class );
         spyEndpoint.setExpectedCount( 1 );
 
         camelContext.start();
+        camelContext.getRouteController().stopRoute( "Schedule Report Delivery" );
 
         String contactUuid = syncContactsAndFetchFirstContactUuid();
         String webhookMessage = StreamUtils.copyToString(
@@ -109,8 +110,11 @@ public class TransmitReportRouteBuilderFunctionalTestCase extends AbstractFuncti
         producerTemplate.sendBodyAndHeaders( "jms:queue:dhis2?exchangePattern=InOnly",
             String.format( webhookMessage, contactUuid ), Map.of( "dataSetCode", "MAL_YEARLY" ) );
 
-        spyEndpoint.await( 1, TimeUnit.MINUTES );
+        spyEndpoint.await( 30, TimeUnit.SECONDS );
         assertEquals( 0, spyEndpoint.getReceivedCounter() );
+
+        camelContext.getRouteController().startRoute( "Schedule Report Delivery" );
+
         spyEndpoint.await();
         assertEquals( 1, spyEndpoint.getReceivedCounter() );
     }


### PR DESCRIPTION
Read contact from message body once to eliminate un-deterministic behaviour where contact is sometimes read from stream instead from memory leading to an no content error during deserialisation. From the pilot testing, it appears that adding `streamCaching()` doesn't solve the problem.