### PR TITLE
feat: add createRapidProContact route

### DIFF
--- a/src/main/java/org/hisp/dhis/integration/rapidpro/aggregationStrategy/RapidProContactEnricherAggrStrategy.java
+++ b/src/main/java/org/hisp/dhis/integration/rapidpro/aggregationStrategy/RapidProContactEnricherAggrStrategy.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.integration.rapidpro.aggregationStrategy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.camel.Exchange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+public class RapidProContactEnricherAggrStrategy extends AbstractAggregationStrategy
+{
+    protected static final Logger LOGGER = LoggerFactory.getLogger( RapidProContactEnricherAggrStrategy.class );
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Override
+    protected Exchange doAggregate( Exchange oldExchange, Exchange newExchange )
+        throws
+        Exception
+    {
+        Map<String, Object> originalBody = oldExchange.getMessage().getBody( Map.class );
+        String resourceBody = newExchange.getMessage().getBody( String.class );
+        Map<String, Object> resourceBodyMap = objectMapper.readValue( resourceBody, Map.class );
+        if ( resourceBodyMap.get( "results" ) != null )
+        {
+            originalBody.put( "results", resourceBodyMap.get( "results" ) );
+        }
+        else
+        {
+            LOGGER.warn( String.format( "unexpected result from RapidPro => %s", resourceBody ) );
+        }
+        oldExchange.getMessage().setBody( originalBody );
+        return oldExchange;
+    }
+}
+

--- a/src/main/java/org/hisp/dhis/integration/rapidpro/aggregationStrategy/RapidProContactEnricherAggrStrategy.java
+++ b/src/main/java/org/hisp/dhis/integration/rapidpro/aggregationStrategy/RapidProContactEnricherAggrStrategy.java
@@ -58,7 +58,7 @@ public class RapidProContactEnricherAggrStrategy extends AbstractAggregationStra
         }
         else
         {
-            LOGGER.warn( String.format( "unexpected result from RapidPro => %s", resourceBody ) );
+            LOGGER.warn( String.format( "Unexpected result from RapidPro => %s", resourceBody ) );
         }
         oldExchange.getMessage().setBody( originalBody );
         return oldExchange;

--- a/src/main/java/org/hisp/dhis/integration/rapidpro/route/FetchScheduledTrackerEventsRouteBuilder.java
+++ b/src/main/java/org/hisp/dhis/integration/rapidpro/route/FetchScheduledTrackerEventsRouteBuilder.java
@@ -108,6 +108,7 @@ public class FetchScheduledTrackerEventsRouteBuilder extends AbstractRouteBuilde
                 .toD( "dhis2://get/collection?path=tracker/events&paging=true&arrayName=instances&fields=enrollment,programStage,orgUnit,scheduledAt,occurredAt,event,status&client=#dhis2Client" )
             .end()
             .setProperty( "dueEvents", simple( "${body}" ) )
+            .setProperty( "dueEventsCount", simple( "${body.size}" ) )
             .log( LoggingLevel.INFO, LOGGER, "Fetched ${body.size} due events from DHIS2" );
 
         from( "direct:fetchAttributes" )

--- a/src/main/java/org/hisp/dhis/integration/rapidpro/route/FetchScheduledTrackerEventsRouteBuilder.java
+++ b/src/main/java/org/hisp/dhis/integration/rapidpro/route/FetchScheduledTrackerEventsRouteBuilder.java
@@ -126,7 +126,7 @@ public class FetchScheduledTrackerEventsRouteBuilder extends AbstractRouteBuilde
 
         from( "direct:createRapidProContact" )
             .routeId( "Create RapidPro Contact" )
-            .log( LoggingLevel.INFO, LOGGER, "Synchronising Tracked Entity Instance with RapidPro contact..." )
+            .log( LoggingLevel.INFO, LOGGER, "Creating RapidPro contact for enrollment ${body[enrollment]} with contact URN ${body[contactUrn]} " )
             .setHeader( "Authorization", constant( "Token {{rapidpro.api.token}}" ) )
             .enrich().simple( "{{rapidpro.api.url}}/contacts.json?urn=${body[contactUrn]}&httpMethod=GET" )
             .aggregationStrategy( rapidProContactEnricherAggrStrategy )
@@ -148,7 +148,5 @@ public class FetchScheduledTrackerEventsRouteBuilder extends AbstractRouteBuilde
                 .end()
             .setBody( simple( "${exchangeProperty.originalPayload}" ) )
             .end();
-
-
     }
 }

--- a/src/main/java/org/hisp/dhis/integration/rapidpro/route/FetchScheduledTrackerEventsRouteBuilder.java
+++ b/src/main/java/org/hisp/dhis/integration/rapidpro/route/FetchScheduledTrackerEventsRouteBuilder.java
@@ -34,6 +34,7 @@ import org.hisp.dhis.api.model.Page;
 import org.hisp.dhis.api.model.Pager;
 import org.hisp.dhis.integration.rapidpro.aggregationStrategy.AttributesAggrStrategy;
 import org.hisp.dhis.integration.rapidpro.aggregationStrategy.ProgramStageEventsAggrStrategy;
+import org.hisp.dhis.integration.rapidpro.aggregationStrategy.RapidProContactEnricherAggrStrategy;
 import org.hisp.dhis.integration.rapidpro.aggregationStrategy.TrackedEntityIdAggrStrategy;
 import org.hisp.dhis.integration.rapidpro.processor.FetchDueEventsQueryParamSetter;
 import org.hisp.dhis.integration.rapidpro.processor.SetAttributesEndpointProcessor;
@@ -55,6 +56,9 @@ public class FetchScheduledTrackerEventsRouteBuilder extends AbstractRouteBuilde
 
     @Autowired
     private ProgramStageEventsAggrStrategy programStageEventsAggrStrategy;
+
+    @Autowired
+    private RapidProContactEnricherAggrStrategy rapidProContactEnricherAggrStrategy;
 
     @Autowired
     private FetchDueEventsQueryParamSetter fetchDueEventsQueryParamSetter;
@@ -92,8 +96,8 @@ public class FetchScheduledTrackerEventsRouteBuilder extends AbstractRouteBuilde
                 .marshal().json().transform().body( String.class )
                 .setProperty( "eventPayload", simple( "${body}" ) )
                 .unmarshal().json()
-                .to( "direct:fetchAttributes" );
-
+                .to( "direct:fetchAttributes" )
+                .to("direct:createRapidProContact");
 
         from( "direct:fetchDueEvents" )
             .routeId( "Fetch Due Events" )
@@ -103,8 +107,8 @@ public class FetchScheduledTrackerEventsRouteBuilder extends AbstractRouteBuilde
                 .process( fetchDueEventsQueryParamSetter )
                 .toD( "dhis2://get/collection?path=tracker/events&paging=true&arrayName=instances&fields=enrollment,programStage,orgUnit,scheduledAt,occurredAt,event,status&client=#dhis2Client" )
             .end()
-            .setProperty( "dueEvents", simple("${body}") )
-            .setProperty( "dueEventsCount", simple("${body.size}"))
+            .setProperty( "dueEvents", simple( "${body}" ) )
+            .setProperty( "dueEventsCount", simple( "${body.size}" ) )
             .log( LoggingLevel.INFO, LOGGER, "Fetched ${exchangeProperty.dueEventsCount} due events from DHIS2" );
 
         from( "direct:fetchAttributes" )
@@ -119,5 +123,32 @@ public class FetchScheduledTrackerEventsRouteBuilder extends AbstractRouteBuilde
             .choice().when( simple( "${body[contactUrn]} == null" ) )
                 .log( LoggingLevel.ERROR, LOGGER, "Error while fetching phone number attribute from DHIS2 enrollment ${body[enrollment]}. Hint: Be sure to set the 'dhis2.phone.number.attribute.code' config property." )
                 .stop();
+
+        from( "direct:createRapidProContact" )
+            .routeId( "Create RapidPro Contact" )
+            .log( LoggingLevel.INFO, LOGGER, "Synchronising Tracked Entity Instance with RapidPro contact..." )
+            .setHeader( "Authorization", constant( "Token {{rapidpro.api.token}}" ) )
+            .enrich().simple( "{{rapidpro.api.url}}/contacts.json?urn=${body[contactUrn]}&httpMethod=GET" )
+            .aggregationStrategy( rapidProContactEnricherAggrStrategy )
+            .setProperty( "originalPayload", simple( "${body}") )
+            .choice()
+                .when( simple ("${body[results].size()} > 0" ) )
+                    .log( LoggingLevel.DEBUG, LOGGER, "RapidPro Contact already exists. No action needed." )
+                .otherwise()
+                    .log( LoggingLevel.DEBUG, LOGGER, "RapidPro Contact does not exist. Creating new contact...")
+                    .transform(
+                        datasonnet( "resource:classpath:trackedEntityContact.ds", Map.class, "application/x-java-object",
+                            "application/x-java-object" ) )
+                    .setHeader( "Authorization", constant( "Token {{rapidpro.api.token}}" ) )
+                    .marshal().json().convertBodyTo( String.class )
+                    .toD( "{{rapidpro.api.url}}/contacts.json?httpMethod=POST&okStatusCodeRange=200-499" )
+                    .choice().when( header( Exchange.HTTP_RESPONSE_CODE ).isNotEqualTo( "201" ) )
+                        .log( LoggingLevel.WARN, LOGGER, "Unexpected status code when creating RapidPro contact for DHIS2 enrollment ${exchangeProperty.originalPayload[enrollment]} with contact URN ${exchangeProperty.originalPayload[contactUrn]} => HTTP ${header.CamelHttpResponseCode}. HTTP response body => ${body}" )
+                    .end()
+                .end()
+            .setBody( simple( "${exchangeProperty.originalPayload}" ) )
+            .end();
+
+
     }
 }

--- a/src/main/java/org/hisp/dhis/integration/rapidpro/route/FetchScheduledTrackerEventsRouteBuilder.java
+++ b/src/main/java/org/hisp/dhis/integration/rapidpro/route/FetchScheduledTrackerEventsRouteBuilder.java
@@ -133,9 +133,9 @@ public class FetchScheduledTrackerEventsRouteBuilder extends AbstractRouteBuilde
             .setProperty( "originalPayload", simple( "${body}") )
             .choice()
                 .when( simple ("${body[results].size()} > 0" ) )
-                    .log( LoggingLevel.DEBUG, LOGGER, "RapidPro Contact already exists. No action needed." )
+                    .log( LoggingLevel.DEBUG, LOGGER, "RapidPro Contact already exists for DHIS2 enrollment ${exchangeProperty.originalPayload[enrollment]} with contact URN ${exchangeProperty.originalPayload[contactUrn]}. No action needed." )
                 .otherwise()
-                    .log( LoggingLevel.DEBUG, LOGGER, "RapidPro Contact does not exist. Creating new contact...")
+                    .log( LoggingLevel.DEBUG, LOGGER, "RapidPro Contact does not exist for DHIS2 enrollment ${exchangeProperty.originalPayload[enrollment]} with contact URN ${exchangeProperty.originalPayload[contactUrn]}. Creating new contact...")
                     .transform(
                         datasonnet( "resource:classpath:trackedEntityContact.ds", Map.class, "application/x-java-object",
                             "application/x-java-object" ) )

--- a/src/main/resources/trackedEntityContact.ds
+++ b/src/main/resources/trackedEntityContact.ds
@@ -1,0 +1,3 @@
+{
+  urns: (if std.objectHas(body, "contactUrn") && !ds.isBlank(body.contactUrn) then [body.contactUrn] else [])
+}

--- a/src/test/java/org/hisp/dhis/integration/rapidpro/Environment.java
+++ b/src/test/java/org/hisp/dhis/integration/rapidpro/Environment.java
@@ -449,12 +449,13 @@ public final class Environment
         IOException,
         ParseException
     {
+        int phoneNumber = 21000000;
         for ( int i = 0; i < numOfTrackedEntities; i++ )
         {
             String firstName = faker.name().firstName();
-            String phoneNumber = faker.phoneNumber().cellPhone();
             String id = faker.idNumber().valid();
-            createDhis2TrackedEntityWithEnrollment( orgUnitId, phoneNumber, "ID-" + id, firstName, programStageIds );
+            createDhis2TrackedEntityWithEnrollment( orgUnitId, String.valueOf( phoneNumber ), "ID-" + id, firstName, programStageIds );
+            phoneNumber++;
         }
     }
 

--- a/src/test/java/org/hisp/dhis/integration/rapidpro/route/FetchScheduledTrackerEventsRouteBuilderFunctionalTestCase.java
+++ b/src/test/java/org/hisp/dhis/integration/rapidpro/route/FetchScheduledTrackerEventsRouteBuilderFunctionalTestCase.java
@@ -404,7 +404,7 @@ public class FetchScheduledTrackerEventsRouteBuilderFunctionalTestCase extends A
         ((SpringBootCamelContext) camelContext)
             .addLogListener( ( Exchange exchange, CamelLogger camelLogger, String message ) -> {
                 if ( camelLogger.getLevel().name().equals( "DEBUG" ) && message.startsWith(
-                    "RapidPro Contact already exists. No action needed." ) )
+                    "RapidPro Contact already exists for DHIS2" ) )
                 {
                     expectedLogMessage.countDown();
                 }

--- a/src/test/java/org/hisp/dhis/integration/rapidpro/route/FetchScheduledTrackerEventsRouteBuilderFunctionalTestCase.java
+++ b/src/test/java/org/hisp/dhis/integration/rapidpro/route/FetchScheduledTrackerEventsRouteBuilderFunctionalTestCase.java
@@ -413,6 +413,7 @@ public class FetchScheduledTrackerEventsRouteBuilderFunctionalTestCase extends A
         camelContext.start();
         Map<String, Object> body = new HashMap<>();
         body.put( "contactUrn", "whatsapp:12345678" );
+        body.put( "enrollment", "enrollment-id" );
         producerTemplate.sendBody( "direct:createRapidProContact", body );
         assertEquals( 2, expectedLogMessage.getCount() );
         producerTemplate.sendBody( "direct:createRapidProContact", body );

--- a/src/test/java/org/hisp/dhis/integration/rapidpro/route/FetchScheduledTrackerEventsRouteBuilderFunctionalTestCase.java
+++ b/src/test/java/org/hisp/dhis/integration/rapidpro/route/FetchScheduledTrackerEventsRouteBuilderFunctionalTestCase.java
@@ -51,6 +51,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hisp.dhis.integration.rapidpro.Environment.DHIS2_CLIENT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -355,4 +357,75 @@ public class FetchScheduledTrackerEventsRouteBuilderFunctionalTestCase extends A
         Thread.sleep( 2000 );
         assertEquals( 0, expectedLogMessage.getCount() );
     }
+
+    @Test
+    public void testCreateRapidProContactGivenValidUrn()
+        throws
+        IOException
+    {
+        assertRapidProPreCondition();
+        camelContext.start();
+        Map<String, Object> body = new HashMap<>();
+        body.put( "contactUrn", "whatsapp:12345678" );
+        producerTemplate.sendBody( "direct:createRapidProContact", body );
+        given( RAPIDPRO_API_REQUEST_SPEC ).get( "contacts.json" ).then()
+            .body( "results.size()", equalTo( 1 ) )
+            .body( "results[0].urns[0]", equalTo( "whatsapp:12345678" ) );
+    }
+
+    @Test
+    public void testCreateRapidProContactFailsGivenInvalidUrn()
+        throws
+        Exception
+    {
+        assertRapidProPreCondition();
+        CountDownLatch expectedLogMessage = new CountDownLatch( 1 );
+        ((SpringBootCamelContext) camelContext)
+            .addLogListener( ( Exchange exchange, CamelLogger camelLogger, String message ) -> {
+                if ( camelLogger.getLevel().name().equals( "WARN" ) && message.startsWith(
+                    "Unexpected status code when creating RapidPro contact for " ) )
+                {
+                    expectedLogMessage.countDown();
+                }
+                return message;
+            } );
+        camelContext.start();
+        Map<String, Object> body = new HashMap<>();
+        body.put( "contactUrn", "whatsapp:invalid" );
+        producerTemplate.sendBody( "direct:createRapidProContact", body );
+        assertEquals( 0, expectedLogMessage.getCount() );
+    }
+
+    @Test
+    public void testCreateRapidProContactWhenContactAlreadyExists()
+    {
+        assertRapidProPreCondition();
+        CountDownLatch expectedLogMessage = new CountDownLatch( 2 );
+        ((SpringBootCamelContext) camelContext)
+            .addLogListener( ( Exchange exchange, CamelLogger camelLogger, String message ) -> {
+                if ( camelLogger.getLevel().name().equals( "DEBUG" ) && message.startsWith(
+                    "RapidPro Contact already exists. No action needed." ) )
+                {
+                    expectedLogMessage.countDown();
+                }
+                return message;
+            } );
+        camelContext.start();
+        Map<String, Object> body = new HashMap<>();
+        body.put( "contactUrn", "whatsapp:12345678" );
+        producerTemplate.sendBody( "direct:createRapidProContact", body );
+        assertEquals( 2, expectedLogMessage.getCount() );
+        producerTemplate.sendBody( "direct:createRapidProContact", body );
+        assertEquals( 1, expectedLogMessage.getCount() );
+        given( RAPIDPRO_API_REQUEST_SPEC ).get( "contacts.json" ).then()
+            .body( "results.size()", equalTo( 1 ) );
+    }
+
+    private void assertRapidProPreCondition()
+    {
+        given( RAPIDPRO_API_REQUEST_SPEC ).get( "contacts.json" ).then()
+            .body( "results.size()", equalTo( 0 ) );
+    }
+
+
 }


### PR DESCRIPTION
Added a simple route for RapidPro contact creation based on the contact urn provided by a DHIS2 tracked entity instance. Tried to keep it as lightweight as possible, but it might be an idea to add additional properties such as `given_name`.