### PR TITLE
feat: enqueue processed events

### DIFF
--- a/src/main/java/org/hisp/dhis/integration/rapidpro/processor/EventStatusUpdateProcessor.java
+++ b/src/main/java/org/hisp/dhis/integration/rapidpro/processor/EventStatusUpdateProcessor.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.integration.rapidpro.processor;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class EventStatusUpdateProcessor implements Processor
+{
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Override
+    public void process( Exchange exchange )
+        throws
+        Exception
+    {
+        Map<String, Object> eventPayload = exchange.getProperty( "eventPayload", Map.class );
+        eventPayload.put( "status", "ACTIVE" );
+        eventPayload.put( "occurredAt", LocalDateTime.now().format( DateTimeFormatter.ofPattern( "yyyy-MM-dd" ) ) );
+        exchange.getMessage().setBody( Map.of( "events", List.of( eventPayload ) ) );
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put( "async", "false" );
+        queryParams.put( "importStrategy", "UPDATE" );
+        exchange.getMessage().setHeader( "CamelDhis2.queryParams", queryParams );
+    }
+}

--- a/src/main/java/org/hisp/dhis/integration/rapidpro/route/QueueProgramStageEventsRouteBuilder.java
+++ b/src/main/java/org/hisp/dhis/integration/rapidpro/route/QueueProgramStageEventsRouteBuilder.java
@@ -30,35 +30,26 @@ package org.hisp.dhis.integration.rapidpro.route;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.LoggingLevel;
-import org.hisp.dhis.api.model.Page;
-import org.hisp.dhis.api.model.Pager;
 import org.hisp.dhis.integration.rapidpro.aggregationStrategy.AttributesAggrStrategy;
 import org.hisp.dhis.integration.rapidpro.aggregationStrategy.ProgramStageEventsAggrStrategy;
-import org.hisp.dhis.integration.rapidpro.aggregationStrategy.RapidProContactEnricherAggrStrategy;
 import org.hisp.dhis.integration.rapidpro.aggregationStrategy.TrackedEntityIdAggrStrategy;
+import org.hisp.dhis.integration.rapidpro.processor.EventStatusUpdateProcessor;
 import org.hisp.dhis.integration.rapidpro.processor.FetchDueEventsQueryParamSetter;
 import org.hisp.dhis.integration.rapidpro.processor.SetAttributesEndpointProcessor;
 import org.hisp.dhis.integration.rapidpro.processor.SetProgramStagesPropertyProcessor;
-import org.hisp.dhis.integration.sdk.internal.operation.page.PageIterable;
-import org.jgroups.logging.Log;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 
 @Component
-public class FetchScheduledTrackerEventsRouteBuilder extends AbstractRouteBuilder
+public class QueueProgramStageEventsRouteBuilder extends AbstractRouteBuilder
 {
     @Autowired
     private SetProgramStagesPropertyProcessor setProgramStagesPropertyProcessor;
 
     @Autowired
     private ProgramStageEventsAggrStrategy programStageEventsAggrStrategy;
-
-    @Autowired
-    private RapidProContactEnricherAggrStrategy rapidProContactEnricherAggrStrategy;
 
     @Autowired
     private FetchDueEventsQueryParamSetter fetchDueEventsQueryParamSetter;
@@ -72,6 +63,9 @@ public class FetchScheduledTrackerEventsRouteBuilder extends AbstractRouteBuilde
     @Autowired
     private SetAttributesEndpointProcessor setAttributesEndpointProcessor;
 
+    @Autowired
+    private EventStatusUpdateProcessor eventStatusUpdateProcessor;
+
     @Override
     protected void doConfigure()
         throws
@@ -80,24 +74,26 @@ public class FetchScheduledTrackerEventsRouteBuilder extends AbstractRouteBuilde
         from( "servlet:tasks/syncEvents?muteException=true" )
             .precondition( "{{sync.dhis2.events.to.rapidpro.flows}}" )
             .removeHeaders( "*" )
-            .to( "direct:fetchAndProcessEvents" )
+            .to( "direct:queueEvents" )
             .setHeader( Exchange.CONTENT_TYPE, constant( "application/json" ) )
             .setBody( constant( Map.of( "status", "success", "data", "Fetched and enqueued due program stage events" ) ) )
             .marshal().json();
 
         from( "quartz://fetchDueEvents?cron={{sync.events.schedule.expression:0 0/30 * * * ?}}&stateful=true" )
             .precondition( "{{sync.dhis2.events.to.rapidpro.flows}}" )
-            .to( "direct:fetchAndProcessEvents" );
+            .to( "direct:queueEvents" );
 
-        from( "direct:fetchAndProcessEvents" )
-            .routeId( "Fetch And Process Tracker Events" )
+        from("direct:queueEvents")
+            .routeId( "Queue Program Stage Events" )
             .to( "direct:fetchDueEvents" )
             .split( simple( "${exchangeProperty.dueEvents}" ) )
+                .setProperty( "eventPayload", simple( "${body}" ) )
                 .to( "direct:fetchAttributes" )
-                .to("direct:createRapidProContact")
-                .log( LoggingLevel.DEBUG, LOGGER, "Enqueuing event [event ID = ${body[event]}, enrollment = ${body[enrollment]}, content = ${body}]" )
-                .marshal().json().convertBodyTo( String.class )
-                .to( "jms:queue:events?exchangePattern=InOnly" );
+                .transform( datasonnet( "resource:classpath:event.ds", String.class, "application/x-java-object", "application/json" ) )
+                .to( "jms:queue:events?exchangePattern=InOnly" )
+                .unmarshal().json()
+                .log( LoggingLevel.DEBUG, LOGGER, "Enqueued event [eventId => ${body[event]}, programStage => ${body[programStage]}]" )
+                .to( "direct:updateDhisProgramStageEventStatus" );
 
         from( "direct:fetchDueEvents" )
             .routeId( "Fetch Due Events" )
@@ -124,40 +120,16 @@ public class FetchScheduledTrackerEventsRouteBuilder extends AbstractRouteBuilde
                 .log( LoggingLevel.ERROR, LOGGER, "Error while fetching phone number attribute from DHIS2 enrollment ${body[enrollment]}. Hint: Be sure to set the 'dhis2.phone.number.attribute.code' config property." )
                 .stop();
 
-        from( "direct:createRapidProContact" )
-            .routeId( "Create RapidPro Contact" )
-            .log( LoggingLevel.INFO, LOGGER, "Processing RapidPro contact for DHIS2 enrollment ${body[enrollment]}" )
-            .setHeader( "Authorization", constant( "Token {{rapidpro.api.token}}" ) )
-            .enrich().simple( "{{rapidpro.api.url}}/contacts.json?urn=${body[contactUrn]}&httpMethod=GET" )
-            .aggregationStrategy( rapidProContactEnricherAggrStrategy )
-            .setProperty( "originalPayload", simple( "${body}") )
-            .choice()
-                .when( simple ("${body[results].size()} > 0" ) )
-                    .log( LoggingLevel.DEBUG, LOGGER, "RapidPro Contact already exists for DHIS2 enrollment ${exchangeProperty.originalPayload[enrollment]}. No action needed." )
-                    .setProperty( "contactUuid", simple( "${body[results][0][uuid]}" ) )
-                .otherwise()
-                    .log( LoggingLevel.DEBUG, LOGGER, "RapidPro Contact does not exist for DHIS2 enrollment ${exchangeProperty.originalPayload[enrollment]}. Creating new contact...")
-                    .transform(
-                        datasonnet( "resource:classpath:trackedEntityContact.ds", Map.class, "application/x-java-object",
-                            "application/x-java-object" ) )
-                    .setHeader( "Authorization", constant( "Token {{rapidpro.api.token}}" ) )
-                    .marshal().json().convertBodyTo( String.class )
-                    .toD( "{{rapidpro.api.url}}/contacts.json?httpMethod=POST&okStatusCodeRange=200-499" )
-                    .choice().when( header( Exchange.HTTP_RESPONSE_CODE ).isNotEqualTo( "201" ) )
-                        .log( LoggingLevel.WARN, LOGGER, "Unexpected status code when creating RapidPro contact for DHIS2 enrollment ${exchangeProperty.originalPayload[enrollment]} => HTTP ${header.CamelHttpResponseCode}. HTTP response body => ${body}" )
-                        .stop()
-                    .end()
-                    .unmarshal().json()
-                    .setProperty( "contactUuid", simple( "${body[uuid]}" ) )
-                .end()
-            .setBody( simple( "${exchangeProperty.originalPayload}" ) )
-            .process( exchange -> {
-                String contactUuid = exchange.getProperty( "contactUuid", String.class );
-                Map<String, Object> bodyMap = exchange.getIn().getBody( Map.class );
-                bodyMap.put( "contactUuid", contactUuid );
-                exchange.getIn().setBody( bodyMap );
-            } )
-            .log( LoggingLevel.DEBUG, LOGGER, "Processed RapidPro contact ${body[contactUuid]} for DHIS2 enrollment ${body[enrollment]} => HTTP ${header.CamelHttpResponseCode}. HTTP response body => ${body}" )
+        from("direct:updateDhisProgramStageEventStatus")
+            .routeId( "Update DHIS Program Stage Event Status" )
+            .process( eventStatusUpdateProcessor )
+            .marshal().json().convertBodyTo( String.class )
+            .toD( "dhis2://post/resource?path=tracker&inBody=resource&client=#dhis2Client" )
+            .unmarshal().json()
+            .choice().when( simple( "${body['status']} == 'SUCCESS' || ${body['status']} == 'OK'" ) )
+                .log( LoggingLevel.DEBUG, LOGGER, "Successfully updated DHIS program stage event status for event with ID => ${exchangeProperty.eventPayload['event']}" )
+            .otherwise()
+                .log( LoggingLevel.ERROR, LOGGER, "Unexpected status code when updating the dhis program stage event status for event with ID => ${exchangeProperty.eventPayload['event']}. HTTP ${header.CamelHttpResponseCode}. HTTP response body => ${body}" )
             .end();
     }
 }

--- a/src/main/resources/event.ds
+++ b/src/main/resources/event.ds
@@ -1,0 +1,7 @@
+{
+  event: body.event,
+  enrollment: body.enrollment,
+  programStage: body.programStage,
+  contactUrn: body.contactUrn,
+  givenName: body.givenName
+}


### PR DESCRIPTION
Added extraction of RapidPro contact UUID during contact creation as this is needed during the flow trigger route. The implementation is starting to deviate quite a bit from the first iteration to keep it more generic and clean, so most of the code will now be new. 

* What do you think about adding the processed events to a queue before triggering the events? In this way the logic for fetching the events and triggering the flows will be separated.
* For the flow trigger route the plan is to add pending flow events to a database, with the possibility for retries if the contact is currently active in another flow. The design will be similar to what you have done in the `DeliverReportRouteBuilder`, both in terms of error handling and retry logic. 